### PR TITLE
Better User Id Handling + Bug Fix

### DIFF
--- a/Stellarch/Bot.cs
+++ b/Stellarch/Bot.cs
@@ -154,8 +154,8 @@ namespace BigSister
                 Color = DiscordColor.Red
             };
 
-            deb.WithDescription(String.Format("Filter Trigger(s):```{0}```Excerpt:```{1}```",
-                stringBuilder.ToString(), e.NotatedMessage));
+            deb.WithDescription(String.Format("Filter Trigger(s):```{0}```Excerpt:```ansi\n{1}```",
+                stringBuilder.ToString().Replace("`", "\\`"), e.NotatedMessage.Replace("`", "\\`")));
 
             deb.AddField(@"Author ID", e.User.Id.ToString(), inline: true);
             deb.AddField(@"Author Username", $"{e.User.Username}#{e.User.Discriminator}", inline: true);

--- a/Stellarch/Commands/MuteCommands.cs
+++ b/Stellarch/Commands/MuteCommands.cs
@@ -12,11 +12,14 @@ using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
 using BigSister.ChatObjects;
 using BigSister.Mutes;
+using System.Text.RegularExpressions;
 
 namespace BigSister.Commands
 {
     class MuteCommands : BaseCommandModule
     {
+        static readonly Regex UserIdLookupRegex =
+            new Regex(@"(\d{17,})", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
         [Command("mute"), MinimumRole(Role.CS)]
         public async Task MuteUser(CommandContext ctx, string arg = "")
         {
@@ -30,15 +33,34 @@ namespace BigSister.Commands
 
         //Mute mentioned user
         [Command("mute"), MinimumRole(Role.CS)]
-        public async Task MuteUser(CommandContext ctx, 
-                                            DiscordMember user, 
+        public async Task MuteUser(CommandContext ctx,
+                                            string user, 
                                             [RemainingText]
                                             string args = @"")
         {
-            // Check if they have the permissions to call this command.
-            if (await Permissions.HandlePermissionsCheck(ctx))
+            bool success = false;
+            ulong userId = 0;
+            Match m = UserIdLookupRegex.Match(user);
+
+            if (m.Success && ulong.TryParse(m.Value,
+                                out
+                                ulong a)) // This section is shamelessly stolen from ModerationCommands.cs (including the lookup regex), no I will not say sorry.
             {
-                 await MuteSystem.AddMute(ctx, user, args);
+                userId = a;
+                success = true;
+            }
+            // Check if they have the permissions to call this command.
+            if (await Permissions.HandlePermissionsCheck(ctx) && success)
+            {
+                 await MuteSystem.AddMute(ctx, userId, args);
+            }
+            else
+            {
+                await GenericResponses.SendGenericCommandError(
+                            ctx.Channel,
+                            ctx.Member.Mention,
+                            @"Unable to add mute",
+                            @"I was unable able to add the mute you gave me. The syntax is mute <mention> <time> <reason>.");
             }
         }
 

--- a/Stellarch/Filter/FilterSystem.Filtering.cs
+++ b/Stellarch/Filter/FilterSystem.Filtering.cs
@@ -6,6 +6,8 @@
 
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -41,7 +43,7 @@ namespace BigSister.Filter
         {
             // Only continue if the channel isn't excluded, if the sender isn't the bot, if this isn't sent in PMs, if this wasn't due to an embed, and if this isn't due to a
             // system messages e.g. message pinned, member joins, 
-            if (!Program.Settings.ExcludedChannels.Contains(e.Channel.Id) &&
+            if (!Program.Settings.ExcludedChannels.Contains((ulong)(e.Channel.IsThread ? e.Channel.ParentId : e.Channel.Id)) &&
                !e.Channel.IsPrivate &&
                !e.Author.IsCurrent &&
                 (e.Message.MessageType == MessageType.Default || e.Message.MessageType == MessageType.Reply) && (e.MessageBefore.Content != e.Message.Content))
@@ -97,10 +99,11 @@ namespace BigSister.Filter
 
                     if (mc.Count > 0)
                     {
+                        var matches = new List<Match>(mc.OrderBy(x => x.Index)); // This is so we get a match list sorted based on the position of the matching text, this prevents annotation issues such as "ma%tched text  %"
                         // Let's check every bad word
-                        for (int i = 0; i < mc.Count; i++)
+                        for (int i = 0; i < matches.Count; i++)
                         {
-                            Match match = mc[i];
+                            Match match = matches[i];
                             string badWord = match.Value;
                             int badWordIndex = match.Index;
 

--- a/Stellarch/MentionSnooper/MentionSnooper.cs
+++ b/Stellarch/MentionSnooper/MentionSnooper.cs
@@ -34,7 +34,7 @@ namespace BigSister.MentionSnooper
                     // Get the DiscordMember of each user.
 
                     var mentionedColonistIds = new List<ulong>();
-
+                    
                     foreach (var user in GetMessageMentions(e.Message.Content))
                     {
                         try
@@ -282,7 +282,10 @@ namespace BigSister.MentionSnooper
         private static bool MentionedUsersContains(DiscordMessage message, ulong memberId)
         {
             bool returnVal = false;
+            Regex searchRegex = new Regex($"<@!?{memberId}>", RegexOptions.IgnoreCase);
+            returnVal = searchRegex.IsMatch(message.Content); // Yes this is all extremely lazy, yet somehow I feel this will work better, this will (hopefully) work regardless of whether the user is present in the server
 
+            /* I'm not sure whether this stuff should stay as I'll be going about it in a completely different way above, I will keep it if the above doesn't work the way I expect
             if (message.MentionedUsers.Count() > 0)
             {
                 foreach (var user in message.MentionedUsers)
@@ -304,7 +307,11 @@ namespace BigSister.MentionSnooper
                         returnVal = user.Id == memberId;
                     } // end else
                 } // end foreach
+                
             } // end if
+            */
+
+
 
             return returnVal;
         } // end method

--- a/Stellarch/Rimboard/RimboardSystem.cs
+++ b/Stellarch/Rimboard/RimboardSystem.cs
@@ -141,7 +141,7 @@ namespace BigSister.Rimboard
             //  4) The Rimboard webhook is not default.
             //  5) This was not sent by a bot (requires nocache).
             if (e.Channel.Id != Program.Settings.RimboardChannelId &&
-                !Program.Settings.RimboardExcludedChannels.Contains(e.Channel.Id) &&
+                !Program.Settings.RimboardExcludedChannels.Contains((ulong)(e.Channel.IsThread ? e.Channel.ParentId : e.Channel.Id)) &&
                 Program.Settings.RimboardEnabled &&
                 Program.Settings.RimboardWebhookId != BotSettings.Default.RimboardWebhookId &&
                 // De-cache the message so we can get its author.


### PR DESCRIPTION
Here's all the changes I've done:
**__(MentionSnooper.cs, line 289-311)__**
Replaced
```csharp
if (message.MentionedUsers.Count() > 0)
{
    foreach (var user in message.MentionedUsers)
    {
        if (returnVal)
        {
            break;// NON-SESE ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! ! 
        }

        if (user is null)
        {   // Most likely they've left, so let's try to search the string with a regex.

            Regex searchRegex = new Regex($"<@!{memberId}>", RegexOptions.IgnoreCase);

            returnVal = searchRegex.IsMatch(message.Content);
        }
        else
        {   // They haven't left, we can access their ID.
            returnVal = user.Id == memberId;
        } // end else
    } // end foreach
    
} // end if
```
with
```csharp
bool returnVal = false;
Regex searchRegex = new Regex($"<@!?{memberId}>", RegexOptions.IgnoreCase);
returnVal = searchRegex.IsMatch(message.Content); // Yes this is all extremely lazy, yet somehow I feel this will work better, this will (hopefully) work regardless of whether the user is present in the server
```
- This completely bypasses DSharp's dumb message.MentionedUsers which fails to flag <@!UserId> mentions, while still ignoring embeds containing mentions (so Floppy will not be caught in the crossfire when looking for a mentioned user with it's "Mention has 7 mentions here" embed)

**__(MuteCommands.cs, MuteUser args and appropriate changes)__**
```csharp
[Command("mute"), MinimumRole(Role.CS)]
public async Task MuteUser(CommandContext ctx,
                                    string user, 
                                    [RemainingText]
                                    string args = @"")
{
    bool success = false;
    ulong userId = 0;
    Match m = UserIdLookupRegex.Match(user);

    if (m.Success && ulong.TryParse(m.Value,
                        out
                        ulong a)) // This section is shamelessly stolen from ModerationCommands.cs (including the lookup regex), no I will not say sorry.
    {
        userId = a;
        success = true;
    }
    // Check if they have the permissions to call this command.
    if (await Permissions.HandlePermissionsCheck(ctx) && success)
    {
         await MuteSystem.AddMute(ctx, userId, args);
    }
    else
    {
        await GenericResponses.SendGenericCommandError(
                    ctx.Channel,
                    ctx.Member.Mention,
                    @"Unable to add mute",
                    @"I was unable able to add the mute you gave me. The syntax is mute <mention> <time> <reason>.");
    }
}
```
- Changed arg from DiscordMember user to string user, this allows us to feed in a direct id which will be converted into a ulong if it is valid in the next following lines, again, allowing us to mute users that aren't present in the server.

**__(MuteSystem.cs, AddMute args and appropriate changes)__**
- Changed DiscordMember targetUser paremeter to ulong to fit above change
- Changed all references to targetUser.Id to just targetUser to accompany this change
- Implemented a try catch for the entire code block referencing Guild.GetMemberAsync(targetUser), this allows the command to continue without halting on error in the event of the user not being present in the server, allowing a mute to still be added to the database and it to be still logged
- Implemented a try catch for member.ModifyAsync, which is used for the removal of users from VC, this allows the command to continue without halting on error in the event of Floppy not having the required perms in the server / voice channel