### PR TITLE
Added Discord Account Discrimination

### DIFF
--- a/Stellarch/Admission/Admission.cs
+++ b/Stellarch/Admission/Admission.cs
@@ -20,7 +20,7 @@ namespace BigSister.Admission
         private static async Task AdmitUser(MessageCreateEventArgs e)
         {
             //check channel
-            if(!(e.Channel.Id == 410118895526084609)) { // hardcoded barracks ID cause I'm lazy
+            if(e.Channel.Id != 410118895526084609 || e.Author.IsBot) { // hardcoded barracks ID cause I'm lazy
                 return;
             }
 
@@ -38,11 +38,16 @@ namespace BigSister.Admission
             }
             else //assign role
             {
-                DateTimeOffset cutoffDate = new DateTimeOffset(e.Message.CreationTimestamp.UtcDateTime).AddDays(-14);
-                DiscordRole colonistRole = e.Guild.GetRole(934494665539993611);
-                if (GetJoinedDiscordTime(e.Author.Id) >= cutoffDate)
+                DateTimeOffset cutoffDate = user.JoinedAt.AddDays(-30);
+
+                DiscordRole colonistRole;
+                if(user.CreationTimestamp >= cutoffDate)
                 {
-                    colonistRole = e.Guild.GetRole(1291125653999058955); // If the account is less than 2 weeks old from creation of the message, we are giving them a separate role to prevent giving new alt accounts certain role perms.
+                    colonistRole = e.Guild.GetRole(1291125653999058955); // If the account is less than a month old after joining the discord, we are giving them a separate role to prevent giving new alt accounts certain role perms.
+                }
+                else
+                {
+                    colonistRole = e.Guild.GetRole(934494665539993611);
                 }
                 //only do if not colonist
                 if (!user.Roles.Contains(colonistRole))
@@ -62,8 +67,9 @@ namespace BigSister.Admission
 
             var newColonistRole = e.Guild.GetRole(934494665539993611);
             var oldColonistRole = e.Guild.GetRole(1291125653999058955);
+            var levelRole = e.Guild.GetRole(793924952465735700);
 
-            if (roleList.Contains(e.Guild.GetRole(793924952465735700)) && !user.Roles.Contains(newColonistRole)) // If user has been given the Level 10 role and doesn't already have colonist, run the following
+            if (roleList.Contains(levelRole) && !user.Roles.Contains(newColonistRole)) // If user has been given the Level 10 role and doesn't already have colonist, run the following
             {
                 await user.GrantRoleAsync(newColonistRole);
                 await user.RevokeRoleAsync(oldColonistRole);

--- a/Stellarch/Admission/Admission.cs
+++ b/Stellarch/Admission/Admission.cs
@@ -21,7 +21,7 @@ namespace BigSister.Admission
         private static async Task AdmitUser(MessageCreateEventArgs e)
         {
             //check channel
-            if(e.Channel.Id != 410118895526084609 || e.Author.IsBot) { // hardcoded barracks ID cause I'm lazy
+            if(!Program.Settings.AdmissionEnabled || e.Channel.Id != 410118895526084609 || e.Author.IsBot) { // hardcoded barracks ID cause I'm lazy
                 return;
             }
 
@@ -39,7 +39,7 @@ namespace BigSister.Admission
             }
             else //assign role
             {
-                DateTimeOffset cutoffDate = user.JoinedAt.AddDays(-30);
+                DateTimeOffset cutoffDate = user.JoinedAt.AddDays(-Program.Settings.DaysSinceCreation);
                 bool userAlreadyEnteredBefore = newDiscordUsers.Contains(user.Id); // If the user already entered once within a month of account creation date
 
                 DiscordRole colonistRole;

--- a/Stellarch/BigSister.csproj
+++ b/Stellarch/BigSister.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="4.4.6" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.4.6" />
-    <PackageReference Include="DSharpPlus.Interactivity" Version="4.4.6" />
+    <PackageReference Include="DSharpPlus" Version="4.5.0" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.5.0" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.5.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />

--- a/Stellarch/Bot.cs
+++ b/Stellarch/Bot.cs
@@ -87,7 +87,7 @@ namespace BigSister
             // ----------------
             // Admit
             botClient.MessageCreated += Admission.Admission.BotClient_MessageCreated;
-
+            botClient.GuildMemberUpdated += Admission.Admission.BotClient_GuildMemberUpdated;
 
             // ----------------
             // Reminder timer

--- a/Stellarch/Commands/SettingsCommands.cs
+++ b/Stellarch/Commands/SettingsCommands.cs
@@ -19,7 +19,38 @@ namespace BigSister.Commands
     {
         private string GetEnabledDisabled(bool a)
             => a ? @"enabled" : @"disabled";
+        #region Admission
+        [Command("admission-enabled"), MinimumRole(Role.BotManager)]
+        public async Task AdmissionEnabled(CommandContext ctx, bool enabled)
+        {
+            if (await Permissions.HandlePermissionsCheck(ctx))
+            {
+                Program.UpdateSettings(ref Program.Settings.AdmissionEnabled, enabled);
 
+                string a = GetEnabledDisabled(enabled);
+                await GenericResponses.SendMessageSettingChanged(
+                    channel: ctx.Channel,
+                    mention: ctx.Member.Mention,
+                    title: $"Admission {a}",
+                    valueName: @"Admission",
+                    newVal: a);
+            }
+        }
+        [Command("admission-day-threshold"), MinimumRole(Role.BotManager)]
+        public async Task AdmissionDayThreshold(CommandContext ctx, int daysInt)
+        {
+            if (await Permissions.HandlePermissionsCheck(ctx))
+            {
+                Program.UpdateSettings(ref Program.Settings.DaysSinceCreation, daysInt);
+                await GenericResponses.SendMessageSettingChanged(
+                    channel: ctx.Channel,
+                    mention: ctx.Member.Mention,
+                    title: @"Admission colonist day threshold changed",
+                    valueName: @"admission colonist day threshold",
+                    newVal: daysInt.ToString());
+            }
+        }
+        #endregion
         #region Filter
 
         [Command("excluded-channels"), MinimumRole(Role.BotManager)]

--- a/Stellarch/Filter/FilterSystem.Filtering.cs
+++ b/Stellarch/Filter/FilterSystem.Filtering.cs
@@ -112,9 +112,9 @@ namespace BigSister.Filter
                             {
                                 returnVal.Add(badWord);
                                 message = message.Insert(badWordIndex + annoteSymbolsOffset, "\u001b[4;35m");
-                                annoteSymbolsOffset += 6;
+                                annoteSymbolsOffset += 7;
                                 message = message.Insert(badWordIndex + badWord.Length + annoteSymbolsOffset, "\u001b[0m");
-                                annoteSymbolsOffset += 3; // This all ensures that the ansi color codes are properly added to the correct position in text
+                                annoteSymbolsOffset += 4; // This all ensures that the ansi color codes are properly added to the correct position in text
                             } // end if
                         } // end for
                     } // end if

--- a/Stellarch/Filter/FilterSystem.Filtering.cs
+++ b/Stellarch/Filter/FilterSystem.Filtering.cs
@@ -112,9 +112,9 @@ namespace BigSister.Filter
                             {
                                 returnVal.Add(badWord);
                                 message = message.Insert(badWordIndex + annoteSymbolsOffset, "\u001b[4;35m");
-                                annoteSymbolsOffset += 7;
+                                annoteSymbolsOffset += 6;
                                 message = message.Insert(badWordIndex + badWord.Length + annoteSymbolsOffset, "\u001b[0m");
-                                annoteSymbolsOffset += 4; // This all ensures that the ansi color codes are properly added to the correct position in text
+                                annoteSymbolsOffset += 3; // This all ensures that the ansi color codes are properly added to the correct position in text
                             } // end if
                         } // end for
                     } // end if
@@ -122,9 +122,9 @@ namespace BigSister.Filter
             } // end if
 
             notatedMessage = message;
-
+            notatedMessage = Regex.Replace(notatedMessage, "\\p{Cf}", ""); // Some people deliberately toss in control characters which can massively increase character count without taking up any space, this should hopefully remove a lot of the control characters being abused
             // If the notated message is over 950 characters, let's cut it down a little bit. ANSI color coding does not work above 1000 characters, and the following additional text is 48 characters
-            if (message.Length > 950)
+            if (notatedMessage.Length > 950)
             {
                 notatedMessage = $"{notatedMessage.Substring(0, 950)}\u001b[2;31m...\nMessage is too long to preview.\u001b[0m";
             }

--- a/Stellarch/Filter/FilterSystem.Filtering.cs
+++ b/Stellarch/Filter/FilterSystem.Filtering.cs
@@ -111,7 +111,7 @@ namespace BigSister.Filter
                             if (!IsExcluded(message, badWord, badWordIndex))
                             {
                                 returnVal.Add(badWord);
-                                message = message.Insert(badWordIndex + annoteSymbolsOffset, "\u001b[2;35m");
+                                message = message.Insert(badWordIndex + annoteSymbolsOffset, "\u001b[4;35m");
                                 annoteSymbolsOffset += 7;
                                 message = message.Insert(badWordIndex + badWord.Length + annoteSymbolsOffset, "\u001b[0m");
                                 annoteSymbolsOffset += 4; // This all ensures that the ansi color codes are properly added to the correct position in text
@@ -123,11 +123,10 @@ namespace BigSister.Filter
 
             notatedMessage = message;
 
-            // If the notated message is over 1500 characters, let's cut it down a little bit. I don't want to wait until 2,000 characters
-            // specifically because imo that's risking it.
-            if (message.Length > 1500)
+            // If the notated message is over 950 characters, let's cut it down a little bit. ANSI color coding does not work above 1000 characters, and the following additional text is 48 characters
+            if (message.Length > 950)
             {
-                notatedMessage = $"{notatedMessage.Substring(0, 1500)}...\n**message too long to preview.**";
+                notatedMessage = $"{notatedMessage.Substring(0, 950)}\u001b[2;31m...\nMessage is too long to preview.\u001b[0m";
             }
 
             return returnVal;

--- a/Stellarch/Settings/BotSettings.cs
+++ b/Stellarch/Settings/BotSettings.cs
@@ -18,7 +18,10 @@ namespace BigSister.Settings
         const ulong DEFAULT_CHANNEL = 564290158078197781;
 
         public BotSettings() { }
-
+        // ----------------
+        // Admission
+        public bool AdmissionEnabled = true;
+        public int DaysSinceCreation = 14;
         // ----------------
         // Filter
 


### PR DESCRIPTION
- If user joined the discord within two weeks (configurable within settings) of account creation, give them a restricted colonist role.
- Otherwise, give them the normal role.
- If user gains the level 10 role and does not have the normal colonist role, remove the restricted colonist role and add the new colonist role.
- Admission can now be disabled in settings in event of raid
- Improved filter logs formatting to also underline matches, and display in red text when the message is too long to fully preview